### PR TITLE
Update gemspec for turbolinks 1.1.1

### DIFF
--- a/client_side_validations-turbolinks.gemspec
+++ b/client_side_validations-turbolinks.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = ClientSideValidations::Turbolinks::VERSION
 
   gem.add_dependency 'client_side_validations', '~> 3.2.0'
-  gem.add_dependency 'turbolinks', '~> 1.0.0'
+  gem.add_dependency 'turbolinks', '~> 1.1.1'
 
   gem.add_development_dependency 'rails', '~> 3.2.0'
   gem.add_development_dependency 'mocha'

--- a/lib/client_side_validations/turbolinks/version.rb
+++ b/lib/client_side_validations/turbolinks/version.rb
@@ -1,5 +1,5 @@
 module ClientSideValidations
   module Turbolinks 
-    VERSION = '1.0.0'
+    VERSION = '1.1.1'
   end
 end

--- a/test/base_helper.rb
+++ b/test/base_helper.rb
@@ -3,7 +3,7 @@ require 'bundler'
 Bundler.setup
 require 'rails'
 require 'test/unit'
-require 'mocha'
+require 'mocha/setup'
 
 if RUBY_VERSION >= '1.9.3'
   require 'debugger'

--- a/vendor/assets/javascripts/rails.validations.turbolinks.js
+++ b/vendor/assets/javascripts/rails.validations.turbolinks.js
@@ -1,6 +1,5 @@
-
 /*
-  Client Side Validations - Turbolinks - v1.0.0
+  Client Side Validations - Turbolinks - v1.1.1
   https://github.com/dockyard/client_side_validations-turbolinks
 
   Copyright (c) 2013 DockYard, LLC
@@ -10,7 +9,6 @@
 
 
 (function() {
-
   $(function() {
     return $(document).bind('page:change', function() {
       return $('form[data-validate]').validate();


### PR DESCRIPTION
Please triple check if I messed up something, I'm still new in ruby.

Test passes, client side validations works in my turbolinks powered applications in both development and production environments.

Hope it helps

GT
